### PR TITLE
Add RetScape

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 <p>List of generic projects.</p>
 
 - [myPeriod](https://codeberg.org/etux/myPeriod) - Menstrual cycle tracking app.
+- [RetScape](https://codeberg.org/etux/RetScape) - A graphical [NomadNet](https://github.com/markqvist/NomadNet) page browser.
 
 
 <h2>Widgets.</h2>


### PR DESCRIPTION
A graphical page browser for [NomadNet](https://github.com/markqvist/NomadNet) pages on [Reticulum](https://github.com/markqvist/Reticulum) networks.

Project is under active development.