### PR TITLE
Added: flet-dropzone control

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [flet-carousel](https://github.com/naderidev/flet-carousel) - Carousel sliders pack for Flet.
 - [flet-contrib](https://github.com/flet-dev/flet-contrib) - Flet controls by the community.
 - [flet-stacked](https://github.com/omamkaz/flet-stacked) - a custom Flet control for managing multiple pages with smooth animations.
+- [flet-dropzone](https://github.com/shiena/flet-dropzone) - a DropZone control that accepts dropped files.
 
 <h2>Themes & styles</h2>
 <p>List of projects that extend the styling capabilities of Flet.</p>


### PR DESCRIPTION
[flet-dropzone](https://github.com/shiena/flet-dropzone) is the separation of Drop Zone from https://github.com/flet-dev/flet/pull/4441 into a plugin.
 