### PR TITLE
Add flet-media-scanner to Community Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ but they highlight the ecosystem's creativity and potential while further demons
 - [flet-gnav-bar](https://github.com/programmersd21/flet_gnav_bar) - Google Nav Bar style animated bottom navigation. Wraps [`google_nav_bar`](https://pub.dev/packages/google_nav_bar).
 - [flet-health](https://github.com/brunobrown/flet-health) - Read and write health data from Apple HealthKit and Google Health Connect. Wraps [`health`](https://pub.dev/packages/health).
 - [flet-material-symbols](https://github.com/Creeper19472/flet-material-symbols) - Google's Material Symbols icon set for Flet. Wraps [`material_symbols_icons`](https://pub.dev/packages/material_symbols_icons).
+- [flet-media-scanner](https://github.com/fazi-gondal/flet-media-scanner) - Flet extension for Android MediaStore integration that saves, lists, and deletes videos in the device Gallery without broad storage permissions.
 - [flet_math](https://github.com/Bbalduzz/flet_math) - Renders LaTeX and TeX math formulas. Wraps [`flutter_math_fork`](https://pub.dev/packages/flutter_math_fork).
 - [flet_notifications](https://github.com/Bbalduzz/flet_notifications) - Local and scheduled notifications. Wraps [`flutter_local_notifications`](https://pub.dev/packages/flutter_local_notifications).
 - [flet-onesignal](https://github.com/brunobrown/flet-onesignal) - Push notifications and in-app messaging. Wraps [`onesignal_flutter`](https://pub.dev/packages/onesignal_flutter).

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ but they highlight the ecosystem's creativity and potential while further demons
 - [flet-gnav-bar](https://github.com/programmersd21/flet_gnav_bar) - Google Nav Bar style animated bottom navigation. Wraps [`google_nav_bar`](https://pub.dev/packages/google_nav_bar).
 - [flet-health](https://github.com/brunobrown/flet-health) - Read and write health data from Apple HealthKit and Google Health Connect. Wraps [`health`](https://pub.dev/packages/health).
 - [flet-material-symbols](https://github.com/Creeper19472/flet-material-symbols) - Google's Material Symbols icon set for Flet. Wraps [`material_symbols_icons`](https://pub.dev/packages/material_symbols_icons).
-- [flet-media-scanner](https://github.com/fazi-gondal/flet-media-scanner) - Flet extension for Android MediaStore integration that saves, lists, and deletes videos in the device Gallery without broad storage permissions.
+- [flet-media-scanner](https://github.com/fazi-gondal/flet-media-scanner) - Android MediaStore integration for saving, listing, deleting, and scanning videos in the device Gallery without broad storage permissions. Wraps [`media_scanner`](https://pub.dev/packages/media_scanner).
 - [flet_math](https://github.com/Bbalduzz/flet_math) - Renders LaTeX and TeX math formulas. Wraps [`flutter_math_fork`](https://pub.dev/packages/flutter_math_fork).
 - [flet_notifications](https://github.com/Bbalduzz/flet_notifications) - Local and scheduled notifications. Wraps [`flutter_local_notifications`](https://pub.dev/packages/flutter_local_notifications).
 - [flet-onesignal](https://github.com/brunobrown/flet-onesignal) - Push notifications and in-app messaging. Wraps [`onesignal_flutter`](https://pub.dev/packages/onesignal_flutter).


### PR DESCRIPTION
<!--
Thanks for improving Awesome Flet! One project per pull request, please.
See CONTRIBUTING.md for the full guidelines.
-->

### What you're adding

<!-- The project name, its link, and one line on what it does. -->


### Section

<!-- e.g. Libraries · Community Extensions · Apps and Projects · Published Apps · Tools · Learning Resources · Community -->


### Checklist

- [ ] Genuinely related to or built with Flet
- [ ] One project per PR
- [ ] Placed in the most specific section, kept alphabetical
- [ ] Description is one short, factual sentence ending with a period
- [ ] Link text is the project's name; link is its GitHub repo (PyPI only if there is no repo)
- [ ] Not already in the list
- [ ] If it's an extension wrapping a Flutter/native package, the description names it — `Wraps [package](https://pub.dev/packages/...)`

### Published app? (delete this block if not)

- [ ] Added to `apps.yml` (not the README table directly)
- [ ] Ran `uv run scripts/apps.py sync` and committed the regenerated README — or left it for a reviewer
- [ ] Includes a working store link; `source` added only if the app's **own** code is public

<!-- Anything else worth knowing? Evidence it's built with Flet, why it belongs, etc. -->
