### PR TITLE
Add flet-webview-all to the README.md list

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ but they highlight the ecosystem's creativity and potential while further demons
 - [flet-open-file](https://github.com/creeper19472/flet-open-file) - Open files with the device's native handler app. Wraps [`open_file`](https://pub.dev/packages/open_file).
 - [flet-sherpa-onnx](https://github.com/SamYuan1990/flet_sherpa_onnx) - On-device speech-to-text. Wraps [`sherpa_onnx`](https://pub.dev/packages/sherpa_onnx).
 - [sparkle_auto_updater](https://github.com/ap4499/sparkle_auto_updater) - Push automatic desktop-app updates. Wraps [`auto_updater`](https://pub.dev/packages/auto_updater).
+- [flet-webview-all](https://github.com/zaim-tech/flet-webview-all) - Cross-platform WebView extension for Flet. Wraps [`webview_all`](https://pub.dev/packages/webview_all).
 
 ## Libraries
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ but they highlight the ecosystem's creativity and potential while further demons
 - [flet-onesignal](https://github.com/brunobrown/flet-onesignal) - Push notifications and in-app messaging. Wraps [`onesignal_flutter`](https://pub.dev/packages/onesignal_flutter).
 - [flet-open-file](https://github.com/creeper19472/flet-open-file) - Open files with the device's native handler app. Wraps [`open_file`](https://pub.dev/packages/open_file).
 - [flet-sherpa-onnx](https://github.com/SamYuan1990/flet_sherpa_onnx) - On-device speech-to-text. Wraps [`sherpa_onnx`](https://pub.dev/packages/sherpa_onnx).
+- [flet-webview-all](https://github.com/zaim-tech/flet-webview-all) - Embeds web content across multiple platforms in Flet apps. Wraps [`webview_all`](https://pub.dev/packages/webview_all)
 - [sparkle_auto_updater](https://github.com/ap4499/sparkle_auto_updater) - Push automatic desktop-app updates. Wraps [`auto_updater`](https://pub.dev/packages/auto_updater).
-- [flet-webview-all](https://github.com/zaim-tech/flet-webview-all) - Cross-platform WebView extension for Flet. Wraps [`webview_all`](https://pub.dev/packages/webview_all).
 
 ## Libraries
 


### PR DESCRIPTION
What you're adding
[flet-webview-all](https://github.com/zaim-tech/flet-webview-all) - Embeds web content across multiple platforms in Flet apps. Wraps [webview_all](https://pub.dev/packages/webview_all).

Section
Community Extensions

Checklist
[x] Genuinely related to or built with Flet

[x] One project per PR

[x] Placed in the most specific section, kept alphabetical

[x] Description is one short, factual sentence ending with a period

[x] Link text is the project's name; link is its GitHub repo (PyPI only if there is no repo)

[x] Not already in the list

[x] If it's an extension wrapping a Flutter/native package, the description names it — Wraps [package](https://pub.dev/packages/...)