### PR TITLE
Add flet-image-viewer to the list of Flet packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ but they highlight the ecosystem's creativity and potential while further demons
 - [flet-dropzone](https://github.com/shiena/flet-dropzone) - Drop zone control that accepts dropping files to your Flet desktop app. Wraps [`desktop_drop`](https://pub.dev/packages/desktop_drop).
 - [flet-gnav-bar](https://github.com/programmersd21/flet_gnav_bar) - Google Nav Bar style animated bottom navigation. Wraps [`google_nav_bar`](https://pub.dev/packages/google_nav_bar).
 - [flet-health](https://github.com/brunobrown/flet-health) - Read and write health data from Apple HealthKit and Google Health Connect. Wraps [`health`](https://pub.dev/packages/health).
+- [flet-image-viewer](https://github.com/zaim-tech/flet-image-viewer) - A zoomable image viewer and swipeable gallery control for Flet. Wraps [`photo_viewer`](https://pub.dev/packages/photo_viewer).
 - [flet-material-symbols](https://github.com/Creeper19472/flet-material-symbols) - Google's Material Symbols icon set for Flet. Wraps [`material_symbols_icons`](https://pub.dev/packages/material_symbols_icons).
 - [flet-media-scanner](https://github.com/fazi-gondal/flet-media-scanner) - Android MediaStore integration for saving, listing, deleting, and scanning videos in the device Gallery without broad storage permissions. Wraps [`media_scanner`](https://pub.dev/packages/media_scanner).
 - [flet_math](https://github.com/Bbalduzz/flet_math) - Renders LaTeX and TeX math formulas. Wraps [`flutter_math_fork`](https://pub.dev/packages/flutter_math_fork).


### PR DESCRIPTION
### What you're adding

[flet-image-viewer](https://github.com/zaim-tech/flet-image-viewer) - A zoomable image viewer and swipeable gallery control for Flet. Wraps [`photo_viewer`](https://pub.dev/packages/photo_viewer).


### Section

Community Extensions


### Checklist

- [x] Genuinely related to or built with Flet
- [x] One project per PR
- [x] Placed in the most specific section, kept alphabetical
- [x] Description is one short, factual sentence ending with a period
- [x] Link text is the project's name; link is its GitHub repo (PyPI only if there is no repo)
- [x] Not already in the list
- [x] If it's an extension wrapping a Flutter/native package, the description names it — `Wraps [package](https://pub.dev/packages/...)`